### PR TITLE
Feat #162170710 Add password reset functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "migrate": "sequelize db:migrate",
     "migrate:test": "sequelize db:migrate:undo:all && npm run migrate",
     "postinstall": "npm run dev",
-    "test": "export NODE_ENV=test && npm run migrate:test && nyc --reporter=html --reporter=text mocha --recursive --require babel-register --exit",
+    "test": "export NODE_ENV=test && npm run migrate:test && nyc --reporter=html --reporter=text mocha --recursive --require babel-register --exit --timeout 20000",
     "test:watch": "nodemon --watch test --exec npm test",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/src/controllers/sendResetToken.js
+++ b/src/controllers/sendResetToken.js
@@ -1,0 +1,101 @@
+import models from '../db/models';
+import { sendgrid } from '../middlewares/helper';
+import { generateToken } from '../middlewares/authentication';
+
+const { User } = models;
+
+/**
+  * @description class representing reset user password
+  *
+  * @class SendResettoken
+  */
+class SendResetToken {
+  /**
+    * @description - This method is responsible for creating password reset token
+    *
+    * @static
+    * @param {object} request - Request sent to the router
+    * @param {object} response - Response sent from the controller
+    *
+    * @returns {object} - object representing response message
+    *
+    */
+  static async resetToken(request, response) {
+    const { HOST_URL } = process.env;
+    try {
+      const { email } = request.body;
+      if (email.trim().length < 1) {
+        return response.status(400).json({
+          status: 'Fail',
+          message: 'The email field cannot be empty'
+        });
+      }
+      const userData = await User.findOne({
+        where: { email }
+      });
+
+      if (!userData) {
+        return response.status(400).json({
+          status: 'Fail',
+          message: 'The email does not exist, please sign up.',
+        });
+      }
+
+      const { id, username } = userData.dataValues;
+      const payload = { id, email, username };
+      const time = { expiresIn: '24hr' };
+      const userToken = generateToken({ payload }, time);
+      await sendgrid(userData.email, 'noreply@authors.com', HOST_URL, userToken);
+      response.status(200).json({
+        status: 'Success',
+        message: 'Password reset link has been sent to your mail',
+        userToken
+      });
+    } catch (error) {
+      response.status(500).json({
+        status: 'Error',
+        error: error.message
+      });
+    }
+  }
+
+  /**
+    * @description - This method is responsible for updating user password
+    *
+    * @static
+    * @param {object} request - Request sent to the router
+    * @param {object} response - Response sent from the controller
+    *
+    * @returns {object} - object representing response message
+    *
+    */
+  static async updateUserPassword(request, response) {
+    const { password, confirmNewPassword } = request.body;
+    try {
+      const { email } = request.decoded;
+      if (password !== confirmNewPassword) {
+        return response.status(400).json({
+          status: 'Fail',
+          message: 'The passwords do not match, confirm and type again.'
+        });
+      }
+      const userToUpdate = await User.findOne({
+        where: { email }
+      });
+      await userToUpdate.update({
+        password,
+      });
+      response.status(200).json({
+        status: 'Success',
+        message: 'Password updated successfully',
+      });
+    } catch (error) {
+      response.status(500).json({
+        status: 'Error',
+        error: error.message,
+      });
+    }
+  }
+}
+const { resetToken, updateUserPassword } = SendResetToken;
+export { resetToken, updateUserPassword };

--- a/src/db/models/User.js
+++ b/src/db/models/User.js
@@ -44,8 +44,11 @@ export default (sequelize, DataTypes) => {
             args: 8,
             msg: 'Password must be at least 8 characters long'
           },
-          isAlphanumeric: {
-            msg: 'Password should be alphanumeric e.g. abc123'
+          isAlphanumeric(value) {
+            value = value.trim();
+            if (!/[^\s\\]/.test(value)) {
+              throw new Error('Password should be alphanumeric e.g. abc123');
+            }
           }
         }
       },
@@ -59,19 +62,26 @@ export default (sequelize, DataTypes) => {
       },
       twitterid: {
         type: DataTypes.STRING,
-        allowNull: true
-      },
-      bio: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      image: {
-        type: DataTypes.STRING,
-        allowNull: true,
-        validate: {
-          isUrl: {
-            args: true,
-            msg: 'Invalid image format'
+        token: {
+          type: DataTypes.STRING,
+          allowNull: true
+        },
+        passwordExpiresIn: {
+          type: DataTypes.BIGINT,
+          allowNull: true
+        },
+        bio: {
+          type: DataTypes.STRING,
+          allowNull: true
+        },
+        image: {
+          type: DataTypes.STRING,
+          allowNull: true,
+          validate: {
+            isUrl: {
+              args: true,
+              msg: 'Invalid image format'
+            }
           }
         }
       },
@@ -88,6 +98,10 @@ export default (sequelize, DataTypes) => {
     {
       hooks: {
         beforeCreate(user) {
+          const rawPassword = user.password;
+          user.password = bcrypt.hashSync(rawPassword, 10);
+        },
+        beforeUpdate(user) {
           const rawPassword = user.password;
           user.password = bcrypt.hashSync(rawPassword, 10);
         }

--- a/src/db/seeders/user.js
+++ b/src/db/seeders/user.js
@@ -164,6 +164,23 @@ const removeSeedUsers = async () => {
 
 const fakeToken = 'nvejvkneje.jhrnejne.nvuenfvemivmnemerfne';
 const incompleteToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp7ImlkIjoxLCJ1c2VybmFtZSI6Imp1d2l6eTI0Nzg5In0sImlhdCI6MTU0Mzc3NzgyOCwiZXhwIjoxNTQzODY0MjI4fQ.VWp2lkDvHZjFsDW7X0_OQhjKIDounpMDYyM_gwvJaR';
+const resetPasswordSuccessful = {
+  email: 'marc@gmail.com',
+};
+const resetPasswordWithWrongEmail = {
+  email: 'okoro@gmail.com',
+};
+const updatePasswordSuccessfully = {
+  password: 'wiseV2424',
+  confirmNewPassword: 'wiseV2424'
+};
+const updateWithWrongPassword = {
+  password: 'wise2424',
+  confirmNewPassword: 'wise242@'
+};
+const emptyResetEmail = {
+  email: '',
+};
 
 export {
   successfulSignup1,
@@ -193,5 +210,10 @@ export {
   invalidImageUrl,
   noImageUpdate,
   noBioUpdate,
-  undefinedPassword
+  undefinedPassword,
+  resetPasswordSuccessful,
+  resetPasswordWithWrongEmail,
+  updatePasswordSuccessfully,
+  updateWithWrongPassword,
+  emptyResetEmail
 };

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -147,6 +147,99 @@ export default {
         }
       }
     },
+    'users/forget': {
+      post: {
+        tags: ['users'],
+        summary: 'Generates token for user reset password',
+        description: '',
+        parameters: [
+          {
+            name: 'user',
+            in: 'body',
+            description: 'Existing user that wants to reset password',
+            schema: {
+              properties: {
+                email: {
+                  required: true,
+                  type: 'string'
+                }
+              }
+            }
+          }
+        ],
+        produces: ['application/json'],
+        responses: {
+          200: {
+            description: 'successful operation',
+            schema: {
+              properties: {
+                message: {
+                  type: 'string'
+                },
+                token: {
+                  type: 'string'
+                }
+              },
+              example: {
+                message: 'Password reset link has been sent to your mail',
+                token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp7ImlkIjoyNSwidXNlcm5hbWUiOiJtYXJjNTAifSwiaWF0IjoxNTQzNzAxMTY2LCJleHAiOjE1NDQ1NjUxNjZ9.jbGxB1LwW3CpT9KyFq9hXdSeztQ8xLrFWE-DQszcmkk'
+              }
+            }
+          },
+          400: {
+            description: 'Invalid email'
+          }
+        }
+      }
+    },
+    'users/passwordupdate': {
+      post: {
+        tags: ['users'],
+        summary: 'Resets user password',
+        description: '',
+        parameters: [
+          {
+            name: 'user',
+            in: 'body',
+            description: 'Existing user that wants to update password',
+            schema: {
+              properties: {
+                newPassword: {
+                  required: true,
+                  type: 'string'
+                },
+                confirmPassword: {
+                  required: true,
+                  type: 'string'
+                },
+              }
+            }
+          }
+        ],
+        produces: ['application/json'],
+        responses: {
+          200: {
+            description: 'successful operation',
+            schema: {
+              properties: {
+                message: {
+                  type: 'string'
+                },
+                token: {
+                  type: 'string'
+                }
+              },
+              example: {
+                message: 'The passwords do not match, confirm and type again.',
+              }
+            }
+          },
+          400: {
+            description: 'Invalid email'
+          }
+        }
+      }
+    },
     '/verification': {
       get: {
         tags: ['email, verification'],

--- a/src/middlewares/helper.js
+++ b/src/middlewares/helper.js
@@ -1,0 +1,39 @@
+import sgMail from '@sendgrid/mail';
+import { verify } from 'jsonwebtoken';
+
+const { TOKEN_SECRET_KEY } = process.env;
+const sendgrid = (toEmail, fromEmail, hostUrl, token) => {
+  sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+  const email = {
+    from: `${fromEmail}`,
+    to: `${toEmail}`,
+    subject: 'noreply',
+    text: 'Email reset link',
+    html: `<a href='#'>follow the link to reset your password${hostUrl}/${token}</a>`
+  };
+  return sgMail.send(email);
+};
+const verifyPasswordResetToken = (request, response, next) => {
+  const { token } = request.query;
+  if (token) {
+    verify(token, TOKEN_SECRET_KEY, (err, decoded) => {
+      if (err) {
+        return response.status(400).json({
+          status: 'Fail',
+          message: 'The link has expired.',
+          error: err,
+          userQuery: request.body,
+        });
+      }
+      request.decoded = decoded.payload.payload;
+      return next();
+    });
+  } else {
+    response.status(400).json({
+      status: 'Fail',
+      message: 'You are not authorized to perform this operation, please provide a token.'
+    });
+  }
+};
+
+export { sendgrid, verifyPasswordResetToken };

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { registerUser, loginUser } from '../controllers/users';
+import { resetToken, updateUserPassword } from '../controllers/sendResetToken';
 import { getCurrentUser, updateProfile } from '../controllers/userProfileHandler';
 import { verifyToken } from '../middlewares/authentication';
 import {
@@ -9,11 +10,14 @@ import {
   checkImageUrl
 } from '../middlewares/updateHandler';
 import checkUndefinedPass from '../middlewares/userAuthHandler';
+import { verifyPasswordResetToken } from '../middlewares/helper';
 
 const userRouter = express.Router();
 
 userRouter.post('/users/signup', checkUndefinedPass, registerUser);
 userRouter.post('/users/login', checkUndefinedPass, loginUser);
+userRouter.post('/users/resetpassword', resetToken);
+userRouter.post('/users/updatepassword', verifyPasswordResetToken, updateUserPassword);
 
 //  route to get details of currently logged in user
 userRouter.get('/user', verifyToken, getCurrentUser);


### PR DESCRIPTION
#### What does this PR do?
Have password reset on Authors-Haven

#### Description of Task to be completed?
Have the following endpoints working
`POST api/users/forget`
`POST api/users/passwordupdate`

#### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm run dev:start`
* With Postman, test every endpoint above

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#162170710

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-12-07 at 4 31 55 am" src="https://user-images.githubusercontent.com/32361413/49626217-1deb9d00-f9d9-11e8-8335-43d576f3e556.png">


<img width="1440" alt="screen shot 2018-12-06 at 8 47 52 pm" src="https://user-images.githubusercontent.com/32361413/49608231-66369b00-f998-11e8-8fc6-36b1f888feed.png">

#### Questions:
N/A