### PR TITLE
[Feature #162170708] Add email verification when user signs up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ addons:
   postgresql: "9.6"
 
 node_js:
-  - '10'
+  - "10"
 
 services:
   - postgresql
- 
+
 before_install:
   - psql -c 'create database ahtestdb;' -U postgres
 
-before_script: 
+before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
@@ -25,5 +25,5 @@ cache:
     - "node_modules"
 
 after_success:
-  - npm run coverage 
+  - npm run coverage
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULTs

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,34 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sendgrid/client": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.3.0.tgz",
+      "integrity": "sha512-fTy8vRpA9Whtf8ULQr/0vkSZaQvGQ97rY5N5PrevKRtugJMsJqFMKO0pwzEWeqITSg71aMMTj57QTgw3SjZvnQ==",
+      "requires": {
+        "@sendgrid/helpers": "^6.3.0",
+        "@types/request": "^2.0.3",
+        "request": "^2.81.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-uTFcmhCDFg/2Uhz+z/cLwyLHH0UsblG49hKwdR7nKbWsGKWv4js7W32FlPdXqy2C/plTJ20vcPLgKM1m3F/MjQ==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "deepmerge": "^2.1.1"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.3.1.tgz",
+      "integrity": "sha512-5zIeAV9iU+0hQkrOQ/D4RB2MfpK+lNbOortIfQdCh95aMDF/TRc9WB8FGNhmQrx9YMuJTms5eiBklF0Fi/dbVg==",
+      "requires": {
+        "@sendgrid/client": "^6.3.0",
+        "@sendgrid/helpers": "^6.3.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -163,6 +191,11 @@
       "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
       "dev": true
     },
+    "@types/caseless": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -175,6 +208,14 @@
       "integrity": "sha512-EIjmpvnHj+T4nMcKwHwxZKUfDmphIKJc2qnEMhSoOvr1lYEQpuRKRz8orWr//krYIIArS/KGGLfL2YGVUYXmIA==",
       "dev": true
     },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/geojson": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
@@ -184,6 +225,17 @@
       "version": "10.12.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
       "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w=="
+    },
+    "@types/request": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
+      }
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -200,6 +252,11 @@
         "@types/cookiejar": "*",
         "@types/node": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -264,7 +321,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2332,7 +2388,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2498,7 +2553,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2506,8 +2560,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -2735,6 +2788,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4408,8 +4466,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -9307,7 +9364,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Andela Simulations Programme",
   "license": "MIT",
   "dependencies": {
+    "@sendgrid/mail": "^6.3.1",
     "babel-register": "6.26.0",
     "bcrypt": "^3.0.2",
     "body-parser": "^1.18.3",

--- a/src/controllers/emailVerifier.js
+++ b/src/controllers/emailVerifier.js
@@ -1,0 +1,67 @@
+import models from '../db/models';
+
+const { User } = models;
+
+/**
+ * @description class representing Email Verification
+ *
+ * @class EmailVerifier
+ */
+class EmailVerifier {
+  /**
+   * @description - This method is responsible for verifying an email
+   *
+   * @static
+   * @param {object} request - Request sent to the router
+   * @param {object} response - Response sent from the controller
+   *
+   * @returns {object} - object representing response message
+   *
+   * @memberof EmailVerifier
+   */
+  static async emailVerifier(request, response) {
+    const { email, emailToken } = request.query;
+    try {
+      const foundUser = await User.find({
+        where: { email }
+      });
+      if (foundUser) {
+        const { isVerified } = foundUser;
+        if (isVerified) {
+          return response.status(204).json({
+            message: 'Email already verified'
+          });
+        }
+        const tokenFound = await User.find({
+          where: { emailtoken: emailToken }
+        });
+        if (tokenFound) {
+          await User.update({ isVerified: true }, { where: { email } });
+          return response.status(201).json({
+            status: 'Success',
+            message: `Your email: ${foundUser.email} has been verified`
+          });
+        }
+        return response.status(404).json({
+          status: 'Fail',
+          message: 'Token not found'
+        });
+      }
+      return response.status(404).json({
+        status: 'Fail',
+        message: 'User not found'
+      });
+    } catch (error) {
+      return response.status(500).json({
+        status: 'Fail',
+        message: 'Something went wrong',
+        error: error.messaage
+      });
+    }
+  }
+}
+
+const { emailVerifier } = EmailVerifier;
+
+export default { emailVerifier };
+

--- a/src/db/migrations/20181126141320-create-user.js
+++ b/src/db/migrations/20181126141320-create-user.js
@@ -40,6 +40,15 @@ export default {
       type: Sequelize.STRING,
       allowNull: true
     },
+    isVerified: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false
+    },
+    emailtoken: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/src/db/models/User.js
+++ b/src/db/models/User.js
@@ -74,6 +74,15 @@ export default (sequelize, DataTypes) => {
             msg: 'Invalid image format'
           }
         }
+      },
+      isVerified: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false
+      },
+      emailtoken: {
+        type: DataTypes.STRING,
+        allowNull: true
       }
     },
     {

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -30,11 +30,15 @@ export default {
     },
     {
       name: 'articles',
-      description: 'The articles created by Author\'s Haven users'
+      description: "The articles created by Author's Haven users"
     },
     {
       name: 'profiles',
-      description: 'The details of the users of Author\'s Haven'
+      description: "The details of the users of Author's Haven"
+    },
+    {
+      name: 'email verification',
+      description: "This verifies a newly registered user's email"
     }
   ],
   schemes: ['https', 'http'],
@@ -139,6 +143,53 @@ export default {
           },
           400: {
             description: 'Invalid login credentials'
+          }
+        }
+      }
+    },
+    '/verification': {
+      get: {
+        tags: ['email, verification'],
+        summary: 'Verify a new user',
+        description: '',
+        parameters: [],
+        produces: ['application/json'],
+        responses: {
+          204: {
+            description: 'Email already verified',
+            schema: {
+              properties: {
+                message: {
+                  type: 'string'
+                }
+              },
+              example: {
+                message: 'Email already verified'
+              }
+            }
+          },
+          201: {
+            description: 'User verified',
+            schema: {
+              properties: {
+                status: {
+                  type: 'string'
+                },
+                message: {
+                  type: 'string'
+                }
+              },
+              example: {
+                status: 'Success',
+                message: 'Your email: johndoe@example.com has been verified'
+              }
+            }
+          },
+          500: {
+            description: 'Encountered an error verifying user'
+          },
+          404: {
+            description: 'User not found'
           }
         }
       }

--- a/src/helpers/emailSender.js
+++ b/src/helpers/emailSender.js
@@ -1,0 +1,24 @@
+import dotenv from 'dotenv';
+import sgMail from '@sendgrid/mail';
+
+dotenv.config();
+
+const emailSenderHelper = (emailToVerify, token) => {
+  const noReplyEmail = process.env.NO_REPLY_MAIL;
+  const hostUrl = process.env.HOST_URL;
+  const sendGridKey = process.env.SENDGRID_API_KEY;
+
+  const url = `${hostUrl}/api/verification/?emailToken=${token}&email=${emailToVerify}`;
+  sgMail.setApiKey(sendGridKey);
+
+  const msg = {
+    from: `${noReplyEmail}`,
+    to: `${emailToVerify}`,
+    subject: 'Please verify your email on Authors Haven',
+    text: 'You are welcome to Author Haven',
+    html: `<strong>Click on the link to verify your email: ${url}</strong>`
+  };
+  sgMail.send(msg);
+};
+
+export default emailSenderHelper;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,9 +3,12 @@ import userRouter from './users';
 import articlesRouter from './articles';
 import profileRouter from './profile';
 import socialAuthRouter from './socialAuth';
+import emailRouter from './verifyEmail';
+
 
 export {
   userRouter,
+  emailRouter,
   articlesRouter,
   profileRouter,
   socialAuthRouter,

--- a/src/routes/verifyEmail.js
+++ b/src/routes/verifyEmail.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { emailVerifier } from '../controllers/emailVerifier';
+
+const emailRouter = express.Router();
+
+emailRouter.get('/verification', emailVerifier);
+
+export default emailRouter;

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,8 @@ import {
   articlesRouter,
   otherRouter,
   profileRouter,
-  socialAuthRouter
+  socialAuthRouter,
+  emailRouter
 } from './routes';
 import registerMiddlewares from './middlewares';
 import './services/passport';
@@ -19,6 +20,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/api', userRouter);
+app.use('/api', emailRouter);
 app.use('/api', articlesRouter);
 app.use('/api', profileRouter);
 app.use('/api/auth', socialAuthRouter);

--- a/test/unit/email/emailVerifier.spec.js
+++ b/test/unit/email/emailVerifier.spec.js
@@ -1,0 +1,124 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import models from '../../../src/db/models';
+import { emailVerifier } from '../../../src/controllers/emailVerifier';
+
+const { User } = models;
+
+const { expect, should } = chai;
+should();
+
+chai.use(chaiHttp);
+chai.use(sinonChai);
+
+describe('Email Verifier', () => {
+  let stubList = [];
+
+  beforeEach(() => {
+    stubList.forEach(stub => stub.restore());
+    stubList = [];
+  });
+
+  it('should not verify an email for invalid user', async () => {
+    const request = {
+      query: {
+        email: 'johndoe@mail.com',
+        token: 'notARealToken'
+      }
+    };
+
+    const response = {
+      status() {},
+      json(args) {
+        return args;
+      }
+    };
+
+    stubList.push(sinon.stub(response, 'status').returnsThis());
+    stubList.push(sinon.stub(User, 'find').returns(false));
+
+    const result = await emailVerifier(request, response);
+
+    response.status.should.have.been.calledWith(404);
+    expect(result).to.have.property('status', 'Fail');
+    expect(result).to.have.property('message', 'User not found');
+  });
+
+  it('should throw a 500 error', async () => {
+    const request = {
+      query: {
+        email: 'johndoe@mail.com',
+        token: 'notARealToken'
+      }
+    };
+
+    const response = {
+      status() {},
+      json(args) {
+        return args;
+      }
+    };
+
+    stubList.push(sinon.stub(response, 'status').returnsThis());
+    stubList.push(sinon.stub(User, 'find').throws());
+
+    const result = await emailVerifier(request, response);
+
+    response.status.should.have.been.calledWith(500);
+    expect(result).to.have.property('status', 'Fail');
+    expect(result).to.have.property('message', 'Something went wrong');
+  });
+
+  it('should not return response for already verified user', async () => {
+    const request = {
+      query: {
+        email: 'johndoe@mail.com',
+        token: 'notARealToken'
+      }
+    };
+
+    const response = {
+      status() {},
+      json(args) {
+        return args;
+      }
+    };
+
+    stubList.push(sinon.stub(response, 'status').returnsThis());
+    stubList.push(sinon.stub(User, 'find').returns({ isVerified: true }));
+
+    const result = await emailVerifier(request, response);
+
+    response.status.should.have.been.calledWith(204);
+    expect(result).to.have.property('message', 'Email already verified');
+  });
+
+  it('should verify user token', async () => {
+    const request = {
+      query: {
+        email: 'johndoe@mail.com',
+        token: 'notARealToken'
+      }
+    };
+
+    const response = {
+      status() {},
+      json(args) {
+        return args;
+      }
+    };
+
+    stubList.push(sinon.stub(response, 'status').returnsThis());
+    stubList.push(sinon.stub(User, 'find').returns({ email: 'johndoe@mail.com', isVerified: false }));
+
+    stubList.push(sinon.stub(User, 'update').returns(true));
+
+    const result = await emailVerifier(request, response);
+
+    response.status.should.have.been.calledWith(201);
+    expect(result).to.have.property('status', 'Success');
+    expect(result).to.have.property('message', 'Your email: johndoe@mail.com has been verified');
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Verifies a newly registered user's email

#### Description of Task to be completed?
has GET `api/verification` endpoint

#### How should this be manually tested?
* `npm install` on the terminal
* `npm run dev:start` to start the server
* navigate to `localhost:3000/api/users/signup` using postman
* signup with `username`, `email` and `password`
* check your email for a verification link and click on the link
* you will get a response like `{"status":"Success","message":"Your email: johndoe@example.com has been verified"}`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162170708](https://www.pivotaltracker.com/story/show/162170708)

#### Screenshots (if appropriate)
<img width="976" alt="email verification inbox" src="https://user-images.githubusercontent.com/32887459/49636280-74210600-fa02-11e8-9653-8418a3b04c42.png">
<img width="1279" alt="email verification" src="https://user-images.githubusercontent.com/32887459/49636281-74b99c80-fa02-11e8-8458-e8eb7db2557b.png">




[Finishes #162170708]