### PR TITLE
#162170716 Implement favorite/unfavorite article functionality

### DIFF
--- a/src/controllers/article.js
+++ b/src/controllers/article.js
@@ -2,6 +2,7 @@ import Slug from 'slug';
 import ArticleModel from '../helpers/articles';
 import { articleAverageRating } from './articleRatingController';
 import TagHelpers from '../helpers/tagHelpers';
+import FavoriteModelHelper from '../helpers/favorite';
 
 /**
  * @description class representing Article Controller
@@ -69,6 +70,7 @@ class ArticleController {
       allArticles = allArticles.map((article) => {
         article = article.toJSON();
         article.tags = article.tags.map(tagname => tagname.name);
+        article.favoritesCount = article.favoritesCount.length;
         return article;
       });
       return response.status(200).json({
@@ -114,9 +116,15 @@ class ArticleController {
    */
   static async getArticle(request, response) {
     const articleSlug = request.params.slug;
+    const { isLoggedIn } = request;
     try {
       const getOneArticle = (await ArticleModel.getOneArticle(articleSlug)).toJSON();
       getOneArticle.tags = getOneArticle.tags.map(tagname => tagname.name);
+      getOneArticle.favoritesCount = getOneArticle.favoritesCount.length;
+      getOneArticle.favorited = isLoggedIn
+        ? await FavoriteModelHelper
+          .hasBeenFavorited(getOneArticle.id, request.userData.payload.id)
+        : false;
       const articleRatingStar = await articleAverageRating(request);
 
       return response.status(200).json({

--- a/src/controllers/favoriteArticleController.js
+++ b/src/controllers/favoriteArticleController.js
@@ -1,0 +1,47 @@
+import errorResponse from '../helpers/index';
+import ArticleModel from '../helpers/articles';
+import FavoriteModelHelper from '../helpers/favorite';
+
+/**
+ * @class FavoriteArticleController
+ */
+class FavoriteArticleController {
+  /**
+   *
+   * @param {*} request - request object
+   * @param {*} response - response object
+   * @returns {void} - redirects to article page
+   */
+  static async favoriteArticle(request, response) {
+    const { slug } = request.params;
+    const userId = request.userData.payload.id;
+    try {
+      const articleId = (await ArticleModel.queryForArticle(slug)).id;
+      await FavoriteModelHelper.favoriteArticle(articleId, userId);
+
+      response.redirect(`/api/articles/${slug}`);
+    } catch (error) {
+      response.status(500).json(errorResponse([error.message]));
+    }
+  }
+
+  /**
+   *
+   * @param {*} request - request object
+   * @param {*} response - response object
+   * @returns {void} - redirects to article page
+   */
+  static async unfavoriteArticle(request, response) {
+    const { slug } = request.params;
+    const userId = request.userData.payload.id;
+    try {
+      const articleId = (await ArticleModel.queryForArticle(slug)).id;
+      await FavoriteModelHelper.unfavoriteArticle(articleId, userId);
+      response.redirect(`/api/articles/${slug}`);
+    } catch (error) {
+      response.status(500).json(errorResponse([error.message]));
+    }
+  }
+}
+
+export default FavoriteArticleController;

--- a/src/db/migrations/20181207015121-create-favorite.js
+++ b/src/db/migrations/20181207015121-create-favorite.js
@@ -1,0 +1,39 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Favorites', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    articleId: {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Articles',
+        key: 'id',
+        as: 'articleId'
+      }
+    },
+    userId: {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Favorites')
+};

--- a/src/db/models/User.js
+++ b/src/db/models/User.js
@@ -114,6 +114,7 @@ export default (sequelize, DataTypes) => {
       as: 'following',
       through: 'Follows'
     });
+    User.hasMany(models.Favorite, { foreignKey: 'userId', as: 'favorites' });
   };
   return User;
 };

--- a/src/db/models/article.js
+++ b/src/db/models/article.js
@@ -74,6 +74,7 @@ export default (sequelize, DataTypes) => {
       as: 'tags',
       foreignKey: 'articleId'
     });
+    Article.hasMany(models.Favorite, { foreignKey: 'articleId', as: 'favoritesCount' });
   };
   return Article;
 };

--- a/src/db/models/favorite.js
+++ b/src/db/models/favorite.js
@@ -1,0 +1,25 @@
+export default (sequelize, DataTypes) => {
+  const Favorite = sequelize.define('Favorite', {
+    articleId: {
+      allowNull: false,
+      type: DataTypes.INTEGER
+    },
+    userId: {
+      allowNull: false,
+      type: DataTypes.INTEGER
+    }
+  });
+
+  Favorite.associate = (models) => {
+    Favorite.belongsTo(models.User, {
+      foreignKey: 'userId',
+      as: 'author',
+      onDelete: 'CASCADE'
+    });
+    Favorite.belongsTo(models.Article, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Favorite;
+};

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -607,7 +607,7 @@ export default {
     },
     '/user': {
       get: {
-        tags: ['user, profile'],
+        tags: ['users', 'profile'],
         summary: 'Gets the profile/details of the currently logged in user',
         description: '',
         parameters: [],
@@ -651,7 +651,7 @@ export default {
         }
       },
       put: {
-        tags: ['users, profile'],
+        tags: ['users', 'profile'],
         summary: 'Gets the profile/details of the currently logged in user',
         description: '',
         parameters: [
@@ -847,7 +847,93 @@ export default {
           }
         ]
       }
-    }
+    },
+    '/articles/:slug/favorite': {
+      post: {
+        tags: ['articles'],
+        summary: 'Favorite an article',
+        produces: ['application/json'],
+        responses: {
+          200: {
+            description: 'article favorited successfully',
+            schema: {
+              properties: {
+                status: {
+                  type: 'string'
+                },
+                message: {
+                  type: 'string'
+                },
+                article: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'number' },
+                    slug: { type: 'string' },
+                    title: { type: 'string' },
+                    description: { type: 'string' },
+                    body: { type: 'string' },
+                    imgUrl: { type: 'string' },
+                    createdAt: { type: 'string' },
+                    updatedAt: { type: 'string' },
+                    author: { type: 'object' },
+                    favoritesCount: { type: 'number' },
+                    favorited: { type: 'boolean' },
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            description: 'Article not found'
+          },
+          403: {
+            description: 'User not authenticated'
+          }
+        }
+      },
+      delete: {
+        tags: ['articles'],
+        summary: 'Unfavorite an article',
+        produces: ['application/json'],
+        responses: {
+          200: {
+            description: 'article unfavorited successfully',
+            schema: {
+              properties: {
+                status: {
+                  type: 'string'
+                },
+                message: {
+                  type: 'string'
+                },
+                article: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'number' },
+                    slug: { type: 'string' },
+                    title: { type: 'string' },
+                    description: { type: 'string' },
+                    body: { type: 'string' },
+                    imgUrl: { type: 'string' },
+                    createdAt: { type: 'string' },
+                    updatedAt: { type: 'string' },
+                    author: { type: 'object' },
+                    favoritesCount: { type: 'number' },
+                    favorited: { type: 'boolean' },
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            description: 'Article not found'
+          },
+          403: {
+            description: 'User not authenticated'
+          }
+        }
+      },
+    },
   },
   definitions: {
     users: {

--- a/src/helpers/articles.js
+++ b/src/helpers/articles.js
@@ -57,6 +57,10 @@ class ArticleModel {
             attributes: []
           }
         },
+        {
+          association: 'favoritesCount',
+          attributes: ['userId']
+        }
       ]
     });
     return allArticle;
@@ -64,10 +68,8 @@ class ArticleModel {
 
   /**
    * @description - This method is responsible for quering the database for an article
-   * @static
-   * @param {object} slug - Request sent to the middleware
-   * @param {object} response - Response sent from the controller
-   * @returns {object} - object representing response message
+   * @param {string} slug
+   * @returns {object} article which found
    * @memberof ArticleModel
    */
   static async getOneArticle(slug) {
@@ -90,6 +92,9 @@ class ArticleModel {
             attributes: []
           }
         },
+        {
+          association: 'favoritesCount'
+        },
       ]
     });
     return oneArticle;
@@ -98,8 +103,7 @@ class ArticleModel {
   /**
    * @description - This method is responsible for quering the database for an article
    * @static
-   * @param {object} slug - Request sent to the middleware
-   * @param {object} response - Response sent from the controller
+   * @param {string} slug
    * @returns {object} - object representing response message
    * @memberof ArticleModel
    */
@@ -165,10 +169,9 @@ class ArticleModel {
   }
 
   /**
-   * @description - This method is responsible for querying the database to delete exising articles
+   * @description - This method is responsible for querying the database to delete existing articles
    * @static
-   * @param {object} slug - Request sent to the middleware
-   * @param {object} response - Response sent from the controller
+   * @param {string} slug
    * @returns {object} - object representing response message
    * @memberof ArticleModel
    */
@@ -192,7 +195,7 @@ class ArticleModel {
   /**
    * @description - This method is responsible for querying the database to check if a slug exists
    * @static
-   * @param {object} slug - Request sent to the middleware
+   * @param {string} slug
    * @returns {object} - object representing response message
    * @memberof ArticleModel
    */

--- a/src/helpers/favorite.js
+++ b/src/helpers/favorite.js
@@ -1,0 +1,45 @@
+import models from '../db/models';
+
+const { Favorite } = models;
+
+/**
+ * @class FavoriteModel
+ */
+class FavoriteModel {
+  /**
+   * @static
+   * @param {number} articleId -id of article being favorited
+   * @param {number} userId - id of user favoriting
+   * @returns {void}
+   * @memberof FavoriteModel
+   */
+  static async favoriteArticle(articleId, userId) {
+    await Favorite
+      .findOrCreate({ where: { articleId, userId }, defaults: { articleId, userId } });
+  }
+
+  /**
+   * @static
+   * @param {number} articleId - article id to check
+   * @param {number} userId - user id who's checking
+   * @returns {Boolean} - true if user has favorited the article
+   */
+  static async hasBeenFavorited(articleId, userId) {
+    const favExists = await Favorite.findOne({
+      where: { articleId, userId }
+    });
+    return !!favExists;
+  }
+
+  /**
+   * @static
+   * @param {number} articleId
+   * @param {number} userId
+   * @returns {void}
+   */
+  static async unfavoriteArticle(articleId, userId) {
+    await Favorite.destroy({ where: { articleId, userId } });
+  }
+}
+
+export default FavoriteModel;

--- a/src/middlewares/authentication.js
+++ b/src/middlewares/authentication.js
@@ -66,6 +66,29 @@ class VerifyUser {
   }
 
   /**
+   * @static
+   * @description checks login status of a request
+   * @param {*} request - request object
+   * @param {*} response response object
+   * @param {*} next - next callback
+   * @returns {*} calls the next middleware
+   * @memberof VerifyUser
+   */
+  static checkAuthStatus(request, response, next) {
+    try {
+      const token = request.headers.authorization || request.body.token;
+      const decoded = jwt.verify(token, process.env.TOKEN_SECRET_KEY);
+
+      request.userData = decoded;
+      request.isLoggedIn = true;
+      next();
+    } catch (error) {
+      request.isLoggedIn = false;
+      next();
+    }
+  }
+
+  /**
    * @description - This method is responsible for checking if a user is valid
    *
    * @static
@@ -97,6 +120,16 @@ class VerifyUser {
   }
 }
 
-const { generateToken, verifyToken, checkUser } = VerifyUser;
+const {
+  generateToken,
+  verifyToken,
+  checkUser,
+  checkAuthStatus
+} = VerifyUser;
 
-export { generateToken, verifyToken, checkUser };
+export {
+  generateToken,
+  verifyToken,
+  checkUser,
+  checkAuthStatus
+};

--- a/src/middlewares/validateArticle.js
+++ b/src/middlewares/validateArticle.js
@@ -14,13 +14,13 @@ const checkInput = (request, response, next) => {
   if (title.trim().length < 3 || title.trim().length > 50) {
     return response.status(400).json({
       status: 'Fail',
-      message: 'Please enter characters  between 3 and 50'
+      message: 'Please enter characters between 3 and 50'
     });
   }
   if (description.trim().length < 5 || description.trim().length > 100) {
     return response.status(400).json({
       status: 'Fail',
-      message: 'Please enter characters  between 5 and 100'
+      message: 'Please enter characters between 5 and 100'
     });
   }
   if (tags === undefined) {

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -2,9 +2,9 @@ import express from 'express';
 import ArticleController from '../controllers/article';
 import Comment from '../controllers/comment';
 import { rateArticle } from '../controllers/articleRatingController';
-
+import FavoriteArticleController from '../controllers/favoriteArticleController';
 import verifySlug from '../middlewares/verifySlug';
-import { verifyToken, checkUser } from '../middlewares/authentication';
+import { verifyToken, checkUser, checkAuthStatus } from '../middlewares/authentication';
 import checkInput from '../middlewares/validateArticle';
 import articleRatingValidatior from '../middlewares/validateRating';
 import PaginationHelper from '../helpers/paginationHelper';
@@ -19,6 +19,8 @@ const {
   deleteArticle
 } = ArticleController;
 
+const { favoriteArticle, unfavoriteArticle } = FavoriteArticleController;
+
 const { slugChecker } = verifySlug;
 
 const articlesBaseEndpoint = '/articles';
@@ -27,12 +29,12 @@ const { checkQueryparameter } = PaginationHelper;
 
 articlesRouter
   .route(articlesBaseEndpoint)
-  .get(checkQueryparameter, getAllArticles)
+  .get(checkAuthStatus, checkQueryparameter, getAllArticles)
   .post(verifyToken, checkInput, createArticle);
 
 articlesRouter
   .route(`${articlesBaseEndpoint}/:slug`)
-  .get(verifyToken, slugChecker, getArticle)
+  .get(checkAuthStatus, slugChecker, getArticle)
   .put(verifyToken, slugChecker, checkUser, updateArticle)
   .delete(verifyToken, slugChecker, checkUser, deleteArticle)
   .post(verifyToken, slugChecker, articleRatingValidatior, rateArticle);
@@ -54,5 +56,10 @@ articlesRouter
 articlesRouter
   .route(`${articlesBaseEndpoint}/:slug/comments/:commentId`)
   .get([slugChecker, Comment.getOne]);
+
+articlesRouter
+  .route(`${articlesBaseEndpoint}/:slug/favorite`)
+  .post(verifyToken, slugChecker, favoriteArticle)
+  .delete(verifyToken, slugChecker, unfavoriteArticle);
 
 export default articlesRouter;

--- a/test/unit/article/article.spec.js
+++ b/test/unit/article/article.spec.js
@@ -122,7 +122,7 @@ describe('Test for article', () => {
 
       expect(response.body)
         .to.have.property('message')
-        .eql('Please enter characters  between 3 and 50');
+        .eql('Please enter characters between 3 and 50');
       expect(response.status).to.equal(400);
     });
 
@@ -134,7 +134,7 @@ describe('Test for article', () => {
 
       expect(response.body)
         .to.have.property('message')
-        .eql('Please enter characters  between 5 and 100');
+        .eql('Please enter characters between 5 and 100');
       expect(response.status).to.equal(400);
     });
 

--- a/test/unit/article/favoriteArticle.spec.js
+++ b/test/unit/article/favoriteArticle.spec.js
@@ -1,0 +1,104 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import app from '../../../src/server';
+import { createArticle } from '../../../src/db/seeders/articles';
+import FavoriteArticleController from '../../../src/controllers/favoriteArticleController';
+import FavoriteModelHelper from '../../../src/helpers/favorite';
+
+chai.use(chaiHttp);
+chai.use(sinonChai);
+const { expect } = chai;
+
+describe('Test for favoriting articles', () => {
+  const data = {};
+  before(async () => {
+    const response = await chai.request(app)
+      .post('/api/users/signup')
+      .send({
+        email: 'kay@gmail.com',
+        username: 'kay',
+        password: 'kay4andela'
+      });
+
+    data.token = response.body.token;
+    const response2 = await chai.request(app)
+      .post('/api/articles')
+      .set('Authorization', data.token)
+      .send(createArticle);
+    data.articleSlug = response2.body.newArticle.slug;
+  });
+
+  it('should favorite an article', async () => {
+    const response = await chai.request(app)
+      .post(`/api/articles/${data.articleSlug}/favorite`)
+      .set('Authorization', data.token);
+
+    expect(response.status).to.eql(200);
+    expect(response.body).to.have.property('getOneArticle');
+    expect(response.body.getOneArticle.favoritesCount).to.eql(1);
+    expect(response.body.getOneArticle.favorited).to.eql(true);
+  });
+
+  it('should unfavorite an article', async () => {
+    const response = await chai.request(app)
+      .del(`/api/articles/${data.articleSlug}/favorite`)
+      .set('Authorization', data.token);
+
+    expect(response.status).to.eql(200);
+    expect(response.body).to.have.property('getOneArticle');
+    expect(response.body.getOneArticle.favoritesCount).to.eql(0);
+    expect(response.body.getOneArticle.favorited).to.eql(false);
+  });
+
+  it('should not favorite an article if unauthenticated', async () => {
+    const response = await chai.request(app)
+      .post(`/api/articles/${data.articleSlug}/favorite`);
+
+    expect(response.status).to.eql(403);
+    expect(response.body.status).to.have.eql('Fail');
+  });
+
+  it('should not unfavorite an article if unauthenticated', async () => {
+    const response = await chai.request(app)
+      .del(`/api/articles/${data.articleSlug}/favorite`);
+
+    expect(response.status).to.eql(403);
+    expect(response.body.status).to.have.eql('Fail');
+  });
+
+  it('should show favorites count even if user is authenticated', async () => {
+    const response = await chai.request(app)
+      .get(`/api/articles/${data.articleSlug}`);
+
+    expect(response.status).to.eql(200);
+    expect(response.body).to.have.property('getOneArticle');
+    expect(response.body.getOneArticle).to.have.property('favorited');
+    expect(response.body.getOneArticle).to.have.property('favoritesCount');
+  });
+
+  it('should fake 500 error for favoriting article', async () => {
+    const request = { userData: { payload: { id: 1 } }, params: { slug: 'some-article' } };
+    const response = { status() {}, json() {} };
+
+    sinon.stub(FavoriteModelHelper, 'favoriteArticle').throws();
+    sinon.stub(response, 'status').returnsThis();
+
+    await FavoriteArticleController.favoriteArticle(request, response);
+
+    expect(response.status).to.have.been.calledWith(500);
+  });
+
+  it('should fake 500 error for unfavoriting article', async () => {
+    const request = { userData: { payload: { id: 1 } }, params: { slug: 'some-article' } };
+    const response = { status() {}, json() {} };
+
+    sinon.stub(FavoriteModelHelper, 'unfavoriteArticle').throws();
+    sinon.stub(response, 'status').returnsThis();
+
+    await FavoriteArticleController.unfavoriteArticle(request, response);
+
+    expect(response.status).to.have.been.calledWith(500);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

Implements favorite/unfavorite article functionality

#### Description of Task to be completed?

- add favorites model
- modify associated models to include favorite article feature
- modify article controller to include an article's fav stats
- add favorite article controller
- add favorite handler routes for favoriting and unfavoriting articles
- write tests for functionality
- document new API endpoints

#### How should this be manually tested?

- clone the repo, `cd` into it, and run `npm install` to install the project's dependencies,
- rename the `env.sample` file to `.env` and fill out the required environmental variables,
- start the local server by running `npm start`, then hit the create an account using the singup endpoint, per the documentation,
- After signing up, create a new article, by hitting the `POST /api/articles` endpoint.
- You can then favorite the article by hitting the `POST /api/articles/:slug/favorite` endpoint
- You can also unfavorite the article by hitting the `DELETE /api/articles/:slug/favorite` endpoint

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

[#162170716](https://www.pivotaltracker.com/story/show/162170716)

#### Screenshots (if appropriate)

<img width="482" alt="screen shot 2018-12-09 at 6 05 12 pm" src="https://user-images.githubusercontent.com/15332525/49702201-fde4f500-fbf5-11e8-951d-9a6f92361c7f.png">

<img width="1440" alt="screen shot 2018-12-09 at 9 05 08 pm" src="https://user-images.githubusercontent.com/15332525/49702229-400e3680-fbf6-11e8-998d-3706288d01cc.png">


#### Questions:

N/A