### PR TITLE
#162170723 Add article read time

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+#### What does this PR do?
+
+
+
+#### Description of Task to be completed?
+
+
+
+#### How should this be manually tested?
+
+
+
+#### Any background context you want to provide?
+
+
+
+#### What are the relevant pivotal tracker stories? (If applicable)
+
+
+
+#### Screenshots (If applicable)
+
+
+
+#### Questions:

--- a/src/controllers/article.js
+++ b/src/controllers/article.js
@@ -87,7 +87,7 @@ class ArticleController {
         message: 'Article not found'
       });
     }
-    ArticleModel.update(request, response, findArticle, articleSlug);
+    await ArticleModel.update(request, response, findArticle, articleSlug);
   }
 
   /**

--- a/src/db/migrations/20181130135013-create-article.js
+++ b/src/db/migrations/20181130135013-create-article.js
@@ -24,6 +24,9 @@ export default {
     userId: {
       type: Sequelize.INTEGER
     },
+    readtime: {
+      type: Sequelize.STRING
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/src/db/models/article.js
+++ b/src/db/models/article.js
@@ -1,39 +1,65 @@
 export default (sequelize, DataTypes) => {
-  const Article = sequelize.define('Article', {
-    id: {
-      allowNull: false,
-      autoIncrement: true,
-      primaryKey: true,
-      type: DataTypes.INTEGER
+  const Article = sequelize.define(
+    'Article',
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: DataTypes.INTEGER
+      },
+      slug: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      title: {
+        allowNull: false,
+        unique: false,
+        type: DataTypes.STRING
+      },
+      description: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      body: {
+        allowNull: false,
+        unique: false,
+        type: DataTypes.TEXT
+      },
+      imgUrl: {
+        allowNull: true,
+        unique: false,
+        type: DataTypes.TEXT
+      },
+      userId: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      readtime: {
+        type: DataTypes.STRING
+      }
     },
-    slug: {
-      allowNull: false,
-      type: DataTypes.STRING
-    },
-    title: {
-      allowNull: false,
-      unique: false,
-      type: DataTypes.STRING
-    },
-    description: {
-      allowNull: false,
-      type: DataTypes.STRING
-    },
-    body: {
-      allowNull: false,
-      unique: false,
-      type: DataTypes.TEXT
-    },
-    imgUrl: {
-      allowNull: true,
-      unique: false,
-      type: DataTypes.TEXT
-    },
-    userId: {
-      allowNull: false,
-      type: DataTypes.INTEGER
+    {
+      hooks: {
+        beforeCreate(article) {
+          const articleBody = article.body;
+          const articleBodyArray = articleBody.split(' ');
+          const readTimeInMinutes = Math.round(articleBodyArray.length / 250) + 1;
+          const readTimeString = `${readTimeInMinutes} mins`;
+          article.readtime = readTimeString;
+        },
+        beforeBulkUpdate(article) {
+          const { body } = article.attributes;
+          const articleBodyArray = body.split(' ');
+          const readTimeInMinutes = Math.round(articleBodyArray.length / 250) + 1;
+          const readTimeString = `${readTimeInMinutes} mins`;
+          article.fields.push('readtime');
+          article.attributes.readtime = readTimeString;
+        }
+      },
     }
-  });
+
+  );
   Article.associate = (models) => {
     Article.belongsTo(models.User, {
       foreignKey: 'userId',

--- a/src/db/seeders/articles.js
+++ b/src/db/seeders/articles.js
@@ -1,19 +1,13 @@
 const createArticle = {
-  title: 'Andela',
-  description: 'Hot Growth',
-  body: 'I want to push my inner self'
-};
-
-const createArticle2 = {
   title: 'Simulations',
   description: 'Do not sweat',
-  body: 'Let us do this!'
+  body: 'I will get there soon how work assigned to you fits into the bigger picture and being able to deliver        n time will set you apart as a competent software developer.Failing to onboard well enough and fast           enough onto a codebase will prevent you from contributing to your product, team or partner and may make       you lose trust as a professional.When you begin working on a product in Simulations, Apprenticeship or        partner work, you will be expected to quickly setup and onboard onto a code base. Leverage the support        of team members and resources to onboard as fast as you can.These are some of the many opportunities in       your career as a software dev that you will need to take ownership of to succeed. The faster you learn        the codebase, the faster you can begin adding value.For a developer to begin delivering on features as        fast as possible, you need to understand your team’s code base quickly.Knowing how work assigned to you       into the bigger picture and being able to deliver in time will set you apart as a competent software          developer. Failing to onboard well enough and fast enough onto a codebase will prevent you from               contributing to your product, team or partner and may make you lose trust as a professional.When you          begin working on a product in Simulations, Apprenticeship or partner work, you will be expected to            quickly setup and onboard onto a code base.Leverage the support of team members and I will get there          soon how work assigned to you fits into the bigger picture and being able to deliver n time will set          you apart as a competent software developer.Failing to onboard well enough and fast enough onto a             codebase will prevent you from contributing to your product, team or partner and may make you lose            trust as a professional.When you begin working on a product in Simulations, Apprenticeship or partner         work, you will be expected to quickly setup and onboard onto a code base. Leverage the support of team        members and resources to onboard as fast as you can.These are some of the many opportunities in your          career as a software dev that you will need to take ownership of to succeed. The faster you learn the         codebase, the faster you can begin adding value.For a developer to begin delivering on features as fast       as possible, you need to understand your team’s code base quickly.Knowing how work assigned to you into       the bigger picture and being able to deliver in time will set you apart as a competent software               developer. Failing to onboard well enough and fast enough onto a codebase will prevent you from               contributing to your product, team or partner and may make you lose trust as a professional.When you          begin working on a product in Simulations, Apprenticeship or partner work, you will be expected to            quickly setup and onboard onto a code base.Leverage the support of team members and'
 };
 
 const updateArticle = {
   title: 'Andela Sims',
   description: 'Clean Ride',
-  body: 'I will get there soon'
+  body: 'I will get there soon how work assigned to you fits into the bigger picture and being able to deliver        n time will set you apart as a competent software developer.Failing to onboard well enough and fast           enough onto a codebase will prevent you from contributing to your product, team or partner and may make       you lose trust as a professional.When you begin working on a product in Simulations, Apprenticeship or        partner work, you will be expected to quickly setup and onboard onto a code base. Leverage the support        of team members and resources to onboard as fast as you can.These are some of the many opportunities in       your career as a software dev that you will need to take ownership of to succeed. The faster you learn        the codebase, the faster you can begin adding value.For a developer to begin delivering on features as        fast as possible, you need to understand your team’s code base quickly.Knowing how work assigned to you       into the bigger picture and being able to deliver in time will set you apart as a competent software          developer. Failing to onboard well enough and fast enough onto a codebase will prevent you from               contributing to your product, team or partner and may make you lose trust as a professional.When you          begin working on a product in Simulations, Apprenticeship or partner work, you will be expected to            quickly setup and onboard onto a code base.Leverage the support of team members and'
 };
 
 const inCompleteArticle = {
@@ -56,11 +50,13 @@ const emptyRating = {
 
 export {
   createArticle,
-  createArticle2,
   updateArticle,
   inCompleteArticle,
   badTitle,
   badDescription,
-  rate2, rate4, rate5,
-  rate6, emptyRating
+  rate2,
+  rate4,
+  rate5,
+  rate6,
+  emptyRating
 };

--- a/src/helpers/articles.js
+++ b/src/helpers/articles.js
@@ -110,16 +110,18 @@ class ArticleModel {
       if (body) {
         updatedData.body = body;
       }
-      await Article.update(updatedData, {
+
+      const updatedArticle = await Article.update(updatedData, {
         returning: true,
         where: {
           slug
         }
       });
+
       return response.status(200).json({
         status: 'Success',
         message: 'Article has been updated successfully',
-        updatedData
+        updatedArticle: updatedArticle[1][0],
       });
     } catch (error) {
       return response.status(500).json({

--- a/test/unit/article/article.spec.js
+++ b/test/unit/article/article.spec.js
@@ -89,6 +89,7 @@ describe('Test for article', () => {
         .to.have.property('message')
         .eql('Article created successfully');
       expect(response.status).to.equal(201);
+      expect(response.body.newArticle.readtime).to.be.equal('4 mins');
     });
 
     it('should post a new article', async () => {
@@ -103,6 +104,7 @@ describe('Test for article', () => {
         .to.have.property('message')
         .eql('Article created successfully');
       expect(response.status).to.equal(201);
+      expect(response.body.newArticle.readtime).to.be.equal('4 mins');
     });
 
     it('should not post a new artivcle with low description length', async () => {
@@ -247,6 +249,7 @@ describe('Test for article', () => {
       expect(response.body.status).to.be.equal('Success');
       expect(response.status).to.equal(200);
       expect(response.body.message).to.be.deep.equals('Article found successfully');
+      expect(response.body.getOneArticle.readtime).to.be.equal('4 mins');
     });
 
     it('should not get an unknown article', async () => {
@@ -278,6 +281,8 @@ describe('Test for article', () => {
         .send(updateArticle);
       expect(response.body.status).to.be.equal('Success');
       expect(response.body.message).to.be.deep.equals('Article has been updated successfully');
+      expect(response.body.updatedArticle.readtime).to.be.equal('2 mins');
+
     });
 
     it('should not update an unknown article', async () => {


### PR DESCRIPTION
#### What does this PR do?
it gets the read time of an article

#### Description of Task to be completed?
has GET /api/articles/:slug
* Add `beforeCreate` hook to the `article` model
* Add `beforeBulkUpdate` hook to the `article` model
* The `beforeCreate` instance operation creates and update the article read time at the point of creating the article
* The `beforeBulkUpdate` bulk operation updates the article read time at the point of the article being updated

#### How should this be manually tested?
- clone the repo
- run `npm install`
- change directory to the project folder
- run `npm run dev:start`
- use postman to navigate `/api/articles` to post an article with the `title`, `description` and `body`
- navigate to `/api/articles/:slug` using postman to update the article with `title`, `description` and `body` 

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162170723](https://www.pivotaltracker.com/story/show/162170723)

#### Screenshots (if appropriate)
* Showing read time after posting an article
<img width="1280" alt="post article readtime" src="https://user-images.githubusercontent.com/32887459/49851256-d1410100-fde0-11e8-9c0a-9d7766f68c4c.png">

* Showing read time for updating an article
<img width="1280" alt="update article readtime" src="https://user-images.githubusercontent.com/32887459/49851356-241ab880-fde1-11e8-8b64-27cef531f848.png">


[Finishes #162170723]